### PR TITLE
missing polish text for Unshey belt description in bgee

### DIFF
--- a/randomiser/languages/bgee/polish/in-game.tra
+++ b/randomiser/languages/bgee/polish/in-game.tra
@@ -1,5 +1,11 @@
 // -*- coding: utf-8 -*-
 
+@115=~Ten elegancki pas uszyto z najwyższą starannością. Sama srebrna sprzączka czyni go całkiem wartościowym. Wyhaftowano na nim imię 'Unshey'.
+
+PARAMETRY:
+
+Waga: 2~
+
 @200=~Rękawice niezdarności: 'Rękawice Przemieszczania Elandera'
 Porywczy Elander stworzył te przeklęte rękawice z myślą o pokonaniu swojego rywala. Wygląda na to, że jego wrodzona złośliwość obróciła się przeciw niemu, gdyż wykonał je tak, by wyglądały jak Rękawice siły ogra, po czym pomylił je chcąc założyć oryginalną parę.
 


### PR DESCRIPTION
I see that's been a while since last activity here, but in case you still support this mod, I found one missing text in Polish translation for BG1 EE. This text exist in "vanilla" language file, but English text was displayed in EE game. After coping it like this, works fine.